### PR TITLE
Feat: 로그인 시 사용자의 SNS TYPE을 받도록 수정

### DIFF
--- a/src/main/java/yapp/bestFriend/model/dto/request/SocialLoginRequest.java
+++ b/src/main/java/yapp/bestFriend/model/dto/request/SocialLoginRequest.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import yapp.bestFriend.model.enumClass.SocialLoginType;
 
 import javax.validation.constraints.NotNull;
 
@@ -15,8 +16,12 @@ import javax.validation.constraints.NotNull;
 public class SocialLoginRequest {
 
     @NotNull
+    @ApiModelProperty(value = "사용자의 SNS TYPE", example = "KAKAO")
+    private SocialLoginType provider;
+
+    @NotNull
     @ApiModelProperty(value = "사용자의 SNS 고유 ID", example = "2242469369")
-    private Long providerId;
+    private String providerId;
 
     @NotNull
     @ApiModelProperty(value = "사용자의 SNS email 주소", example = "test@naver.com")

--- a/src/main/java/yapp/bestFriend/model/entity/User.java
+++ b/src/main/java/yapp/bestFriend/model/entity/User.java
@@ -3,6 +3,7 @@ package yapp.bestFriend.model.entity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import yapp.bestFriend.model.enumClass.SocialLoginType;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -14,7 +15,9 @@ import java.util.List;
 @Entity
 @Table(name = "users",
         uniqueConstraints = {
-                @UniqueConstraint(name = "UniqueEmail", columnNames = {"email"})
+                @UniqueConstraint(
+                        name = "UniqueEmail",
+                        columnNames = {"email","provider","provider_id"})
         })
 public class User extends BaseInfo {
     @Id //pk
@@ -28,6 +31,13 @@ public class User extends BaseInfo {
 
     private String nickName;
 
+    @Column(name = "provider")
+    @Enumerated(EnumType.STRING)
+    private SocialLoginType provider;
+
+    @Column(name = "provider_id")
+    private String providerId;
+
     @Enumerated(EnumType.STRING)//DB로 저장할 떄 Enum 값을 어떤 형태로 저장할지 결정
     private Role role;
 
@@ -38,10 +48,13 @@ public class User extends BaseInfo {
     private UserConnection userConnection;
 
     @Builder
-    public User(String email, String password, String nickName, Role role, UserConnection userConnection, LocalDateTime localDateTime) {
+    public User(String email, String password, String nickName,
+                SocialLoginType provider, String providerId, Role role, UserConnection userConnection, LocalDateTime localDateTime) {
         this.email = email;
         this.password = password;
         this.nickName = nickName;
+        this.provider = provider;
+        this.providerId = providerId;
         this.role = role;
         this.userConnection= userConnection;
         super.createdAt = localDateTime;

--- a/src/main/java/yapp/bestFriend/model/entity/UserConnection.java
+++ b/src/main/java/yapp/bestFriend/model/entity/UserConnection.java
@@ -24,7 +24,7 @@ public class UserConnection extends BaseInfo {
     private SocialLoginType provider;
 
     @Column(name = "provider_id")
-    private Long providerId;
+    private String providerId;
 
     @Column(name = "nick_name")
     private String nickName;
@@ -37,7 +37,7 @@ public class UserConnection extends BaseInfo {
     }
 
     @Builder
-    private UserConnection(String email, SocialLoginType provider, Long providerId, String nickName, String accessToken) {
+    private UserConnection(String email, SocialLoginType provider, String providerId, String nickName, String accessToken) {
         this.email = email;
         this.provider = provider;
         this.providerId = providerId;

--- a/src/main/java/yapp/bestFriend/model/enumClass/SocialLoginType.java
+++ b/src/main/java/yapp/bestFriend/model/enumClass/SocialLoginType.java
@@ -1,5 +1,6 @@
 package yapp.bestFriend.model.enumClass;
 
 public enum SocialLoginType {
-    KAKAO
+    KAKAO,
+    GOOGLE
 }

--- a/src/main/java/yapp/bestFriend/repository/UserConnectionRepository.java
+++ b/src/main/java/yapp/bestFriend/repository/UserConnectionRepository.java
@@ -2,10 +2,13 @@ package yapp.bestFriend.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import yapp.bestFriend.model.entity.UserConnection;
+import yapp.bestFriend.model.enumClass.SocialLoginType;
 
 public interface UserConnectionRepository extends JpaRepository<UserConnection, Long> {
 
     UserConnection findByEmail(String email);
 
     Integer deleteByEmail(String email);
+
+    UserConnection findByEmailAndProviderAndProviderId(String email, SocialLoginType provider, String providerId);
 }

--- a/src/main/java/yapp/bestFriend/repository/UserRepository.java
+++ b/src/main/java/yapp/bestFriend/repository/UserRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import yapp.bestFriend.model.entity.User;
+import yapp.bestFriend.model.entity.UserConnection;
+import yapp.bestFriend.model.enumClass.SocialLoginType;
 
 import java.util.Optional;
 
@@ -15,4 +17,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query(value = "SELECT A FROM User A WHERE A.id = :userId and A.deletedYn = false")
     Optional<User> findById(@Param(value = "userId") Long id);
+
+    User findByEmailAndProviderAndProviderId(String email, SocialLoginType provider, String providerId);
 }

--- a/src/test/java/yapp/bestFriend/service/auth/KakaoOauthTest.java
+++ b/src/test/java/yapp/bestFriend/service/auth/KakaoOauthTest.java
@@ -40,21 +40,24 @@ class KakaoOauthTest {
     @DisplayName("로그아웃한 사용자 로그인 시")
     void requestLogin() {
         //given
-        SocialLoginRequest socialLoginRequest = SocialLoginRequest
-                .builder().providerId(1L)
+        SocialLoginRequest socialLoginRequest = SocialLoginRequest.builder()
+                .providerId("123456789")
+                .provider(SocialLoginType.KAKAO)
                 .email("test@naver.com")
                 .nickName("best friend").build();
 
         UserConnection userConnectionInfo = UserConnection.builder()
                 .email("test@naver.com")
                 .provider(SocialLoginType.KAKAO)
-                .providerId(123456789L)
+                .providerId("123456789")
                 .nickName("best friend")
                 .accessToken("accessToken")
                 .build();
 
         User user = User.builder()
                 .email("test@naver.com")
+                .provider(SocialLoginType.KAKAO)
+                .providerId("123456789")
                 .password("123456")
                 .nickName("best friend")
                 .role(Role.USER)
@@ -65,7 +68,7 @@ class KakaoOauthTest {
         //when
         when(userConnectionRepository.findById(any())).thenReturn(null);
         when(userConnectionRepository.save(any())).thenReturn(userConnectionInfo);
-        when(userRepository.findByEmail("test@naver.com")).thenReturn(user);
+        when(userRepository.findByEmailAndProviderAndProviderId(user.getEmail(), user.getProvider(), user.getProviderId())).thenReturn(user);
         when(userRepository.save(any())).thenReturn(user);
 
         try (MockedStatic<JwtUtil> mockedStatic = mockStatic(JwtUtil.class)) {

--- a/src/test/java/yapp/bestFriend/service/user/UserServiceTest.java
+++ b/src/test/java/yapp/bestFriend/service/user/UserServiceTest.java
@@ -50,7 +50,7 @@ class UserServiceTest {
         UserConnection userConnectionInfo = UserConnection.builder()
                 .email("test@naver.com")
                 .provider(SocialLoginType.KAKAO)
-                .providerId(123456789L)
+                .providerId("123456789")
                 .nickName("best friend")
                 .accessToken("accessToken")
                 .build();


### PR DESCRIPTION
- 변경사항
  - provider id 타입 변경으로 인한 테스트 코드 변경
  - providerId 필드 long 에서 string으로 타입 변경
  - 이메일, provider, provider id 기준으로 조회하는 jpa 메서드 추가
  - 사용자 테이블 내 프로바이더, 프로바이더 id 필드 추가
  - 소셜로그인 타입 Google 추가
  - 로그인 시 사용자의 SNS TYPE을 받도록 수정 