### PR TITLE
Fix: Get products Ver 1.1의 기록 데이터만 가져오도록 not null 조건 추가

### DIFF
--- a/src/main/java/yapp/bestFriend/repository/SavingRecordRepository.java
+++ b/src/main/java/yapp/bestFriend/repository/SavingRecordRepository.java
@@ -63,15 +63,15 @@ public interface SavingRecordRepository extends JpaRepository<SavingRecord, Long
                     "                    where DE between B.startYmd and B.endYmd\n" +
                     "                      and DAY_NUM IN (:intervalList)) \n" +
                     "           end AS totalTimes\n" +
-                    "    FROM SavingRecord A inner join Product B\n" +
-                    "      on A.user.id = B.user.id\n" +
+                    "    FROM Product B LEFT OUTER JOIN SavingRecord A\n" +
+                    "      on (A.user.id = B.user.id\n" +
                     "       AND A.product.id = B.id\n" +
-                    "     where 1=1" +
-                    "AND A.user.id = :userId\n" +
-                    "AND A.product.id in (:productId)\n" +
                     "       AND A.recordYmd between B.startYmd AND B.endYmd\n" +
                     "       and substring(A.recordYmd,1,10) <= :recordYmd\n" +
-                    "       AND A.deletedYn = false\n" +
+                    "       AND A.deletedYn = false)\n" +
+                    "     where 1=1" +
+                    "AND B.user.id = :userId\n" +
+                    "AND B.id in (:productId)\n" +
                     "       AND B.deletedYn = false\n" +
                     "    group by B.id, B.name")
     SavingRecordWithProductInterface searchProductListWithSavingRecord(Long userId, String recordYmd, Long productId, List<String> intervalList);

--- a/src/main/java/yapp/bestFriend/repository/SavingRecordRepository.java
+++ b/src/main/java/yapp/bestFriend/repository/SavingRecordRepository.java
@@ -51,13 +51,13 @@ public interface SavingRecordRepository extends JpaRepository<SavingRecord, Long
     @Query(value =
             "    SELECT B.id as productId,\n" +
                     "           B.name as name,\n" +
-                    "           SUM(CASE WHEN substring(A.recordYmd,1,10) = :recordYmd THEN A.savings ELSE 0 END) AS price,\n" +
-                    "           count(*) AS accmTimes,\n" +
-                    "       case when B.freqType = 1 then (1-count(*))\n" +
+                    "           COALESCE(SUM(CASE WHEN substring(A.recordYmd,1,10) = :recordYmd THEN A.savings ELSE 0 END),0) AS price,\n" +
+                    "           count(A.id) AS accmTimes,\n" +
+                    "       case when B.freqType = 1 then (1-count(B.id))\n" +
                     "            WHEN B.freqType = 2 THEN\n" +
                     "                ((select count(*)\n" +
                     "                 from Calendar \n" +
-                    "                 where DE between B.startYmd and B.endYmd) - count(*))\n" +
+                    "                 where DE between B.startYmd and B.endYmd) - count(B.id))\n" +
                     "            else (select count(*)\n" +
                     "                     from Calendar \n" +
                     "                    where DE between B.startYmd and B.endYmd\n" +
@@ -67,7 +67,8 @@ public interface SavingRecordRepository extends JpaRepository<SavingRecord, Long
                     "      on (A.user.id = B.user.id\n" +
                     "       AND A.product.id = B.id\n" +
                     "       AND A.recordYmd between B.startYmd AND B.endYmd\n" +
-                    "       and substring(A.recordYmd,1,10) <= :recordYmd\n" +
+                    "       and substring(A.recordYmd,1,10) <= :recordYmd" +
+                    "       AND A.savings is not null \n" + //ver 1.1의 데이터만 가져오기 위함
                     "       AND A.deletedYn = false)\n" +
                     "     where 1=1" +
                     "AND B.user.id = :userId\n" +

--- a/src/main/java/yapp/bestFriend/service/v1pt1/ProductServiceV1pt1.java
+++ b/src/main/java/yapp/bestFriend/service/v1pt1/ProductServiceV1pt1.java
@@ -35,19 +35,21 @@ public class ProductServiceV1pt1 {
 
         // 해당 userId로 가입된 사용자가 존재하는 경우
         if(user.isPresent()){
-            try {
-                return getListDefaultRes(user.get(), recordYmd);
-            }catch (Exception e){
-                return DefaultRes.response(HttpStatus.OK.value(), "등록 실패(날짜 형식 오류)");
-            }
+            return getListDefaultRes(user.get(), recordYmd);
         }
         // 해당 userId로 가입된 사용자가 존재하지 않는 경우
         else return DefaultRes.response(HttpStatus.OK.value(), "조회 실패(사용자 정보 없음)");
     }
 
     private DefaultRes<List<yapp.bestFriend.model.dto.res.v1pt.SimpleProductResponse>> getListDefaultRes(User existingUser, String recordYmd) {
-        List<Product> productList = productRepository.findProductList(recordYmd, existingUser.getId(), LocalDateUtil.getDayOfWeek(recordYmd));
+        String dayNumber;
+        try {
+            dayNumber = LocalDateUtil.getDayOfWeek(recordYmd);
+        }catch (Exception e){
+            return DefaultRes.response(HttpStatus.OK.value(), "등록 실패(날짜 형식 오류)");
+        }
 
+        List<Product> productList = productRepository.findProductList(recordYmd, existingUser.getId(), dayNumber);
         if(productList.isEmpty()){
             return DefaultRes.response(HttpStatus.OK.value(), "데이터 없음");
         }

--- a/src/main/java/yapp/bestFriend/service/v1pt1/ProductServiceV1pt1.java
+++ b/src/main/java/yapp/bestFriend/service/v1pt1/ProductServiceV1pt1.java
@@ -56,6 +56,7 @@ public class ProductServiceV1pt1 {
             for(Product p:productList){
                 List<String> intervalList = Arrays.asList(p.getFreqInterval().split(","));
                 SavingRecordWithProductInterface product = savingRecordRepository.searchProductListWithSavingRecord(existingUser.getId(), LocalDateUtil.convertToLocalDate(recordYmd).toString(), p.getId(), intervalList);
+                if(product == null) continue;
                 SimpleProductResponseList.add(new yapp.bestFriend.model.dto.res.v1pt.SimpleProductResponse(
                         product.getProductId(),
                         product.getName(),


### PR DESCRIPTION
- 변경사항: GET /api/products, headers="X-API-VERSION=1.1"
  - 기록이 한 건도 없는 경우에도 데이터 조회되도록 이너조인에서 아우터조인으로 변경
  - 날짜형식 오류 try catch 구문 세분화
  - Ver 1.1의 기록 데이터만 가져오도록 not null 조건 추가